### PR TITLE
Simplify completion task fetcher typing

### DIFF
--- a/src/bhds/api/completion/__init__.py
+++ b/src/bhds/api/completion/__init__.py
@@ -1,13 +1,15 @@
 """Data completion API
 
-Provides independent detectors and executors for data completion tasks.
-"""
+Provides independent detectors and executors for data completion tasks."""
 
 from .detector import DailyKlineDetector, FundingRateDetector
 from .executor import DataExecutor
+from .task import CompletionOperation, CompletionTask
 
 __all__ = [
     "DailyKlineDetector",
-    "FundingRateDetector", 
-    "DataExecutor"
+    "FundingRateDetector",
+    "DataExecutor",
+    "CompletionOperation",
+    "CompletionTask",
 ]

--- a/src/bhds/api/completion/task.py
+++ b/src/bhds/api/completion/task.py
@@ -1,0 +1,41 @@
+"""Task abstractions for data completion workflows."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping
+
+from bdt_common.rest_api.fetcher import BinanceFetcher
+
+
+class CompletionOperation(str, Enum):
+    """Supported operations for completion tasks."""
+
+    GET_KLINE_DF_OF_DAY = "get_kline_df_of_day"
+    GET_HIST_FUNDING_RATE = "get_hist_funding_rate"
+
+    def __str__(self) -> str:  # pragma: no cover - convenience for logging
+        return self.value
+
+
+@dataclass(frozen=True, slots=True)
+class CompletionTask:
+    """Data completion task with deferred execution."""
+
+    operation: CompletionOperation
+    params: Mapping[str, Any]
+    save_path: Path
+
+    def execute(self, fetcher: BinanceFetcher) -> Any:
+        """Execute the task using the provided fetcher."""
+
+        operation = getattr(fetcher, self.operation.value)
+        return operation(**self.params)
+
+    @property
+    def description(self) -> str:
+        """Return a human-readable description of the task."""
+
+        return f"{self.operation}({', '.join(f'{k}={v!r}' for k, v in self.params.items())})"


### PR DESCRIPTION
## Summary
- add a CompletionTask dataclass for completion workflows, with supported operations and execution helper
- expose the new task API through the completion package
- simplify CompletionTask execution typing to require the BinanceFetcher directly

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e4a4841cc88321806f48b0b09d4551